### PR TITLE
Remove custom Result class.

### DIFF
--- a/KalmarKommun.Datalager.Sort.Tests/KalmarKommun.Datalager.Sort.Tests.cs
+++ b/KalmarKommun.Datalager.Sort.Tests/KalmarKommun.Datalager.Sort.Tests.cs
@@ -34,9 +34,9 @@ namespace KalmarKommun.Datalager.Sort.Tests
                 Key = "season"
             };
 
-            var ret = Sort.SortAscendingByParsedIntThenDescendingByText(input, new System.Threading.CancellationToken());
+            var SortedList = Sort.SortAscendingByParsedIntThenDescendingByText(input, new System.Threading.CancellationToken());
 
-            Assert.That(ret.SortedList, Is.EqualTo(new List<Dictionary<string, string>> {
+            Assert.That(SortedList, Is.EqualTo(new List<Dictionary<string, string>> {
                 new Dictionary<string, string> {
                     { "season", "spring-2022" }
                 },

--- a/KalmarKommun.Datalager.Sort/Definition.cs
+++ b/KalmarKommun.Datalager.Sort/Definition.cs
@@ -25,13 +25,4 @@ namespace KalmarKommun.Datalager.Sort
         [DefaultValue("")]
         public string Key { get; set; }
     }
-
-    public class Result
-    {
-        /// <summary>
-        /// Contains SortedList which is ListToSort, sorted by the provided Key.
-        /// </summary>
-        [DisplayFormat(DataFormatString = "Expression")]
-        public List<Dictionary<string, string>> SortedList;
-    }
 }

--- a/KalmarKommun.Datalager.Sort/KalmarKommun.Datalager.Sort.cs
+++ b/KalmarKommun.Datalager.Sort/KalmarKommun.Datalager.Sort.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -11,22 +12,17 @@ namespace KalmarKommun.Datalager.Sort
     {
         /// <summary>
         /// Task for sorting a List of Dicitionaries, based on the values of a key from the Dictionaries.
-        /// 
         /// Documentation: https://github.com/krukle/FrendsTask_KalmarKommun.Datalager.Sort
-        /// 
         /// </summary>
         /// <param name="input">The List to sort, and which key's values to sort by</param>
         /// <param name="cancellationToken"></param>
-        /// <returns>The sorted list of dictionaries.</returns>
-        public static Result SortAscendingByParsedIntThenDescendingByText(Parameters input, CancellationToken cancellationToken)
+        /// <returns> List<Dictionary<string, string>> </returns>
+        public static List<Dictionary<string, string>> SortAscendingByParsedIntThenDescendingByText(Parameters input, CancellationToken cancellationToken)
         {
-            return new Result
-            {
-                SortedList = input.ListToSort
+            return input.ListToSort
                     .OrderBy(x => Int32.Parse(Regex.Match(x[input.Key], @"\d+").Value))
                     .ThenByDescending(x => x[input.Key])
-                    .ToList()
-            };
+                    .ToList();
         }
     }
 }

--- a/KalmarKommun.Datalager.Sort/KalmarKommun.Datalager.Sort.csproj
+++ b/KalmarKommun.Datalager.Sort/KalmarKommun.Datalager.Sort.csproj
@@ -9,7 +9,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.0.3</Version>
+    <Version>0.0.4</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Instead of return the list in a acustom Result class, containing the list. We now return only the List itself, as the previous solution was creating unneccesary onverhead.